### PR TITLE
Run clang-tidy via GitHub Actions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: 'clang-diagnostic-*,-clang-diagnostic-incompatible-pointer-types-discards-qualifiers,bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,performance-*,modernize-*,clang-analyzer-*,-clang-analyzer-optin.portability.UnixAPI'
+...
+

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,28 @@
+name: cpp-linter
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libsdl2-dev
+
+      - uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: '' # disable
+          tidy-checks: '' # use .clang-tidy
+          files-changed-only: false
+
+      - name: fail
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1

--- a/src/Blur.c
+++ b/src/Blur.c
@@ -49,7 +49,7 @@ void blur(double* rasterA, double* rasterB, int width, int height,
             
             int idxA_ = idxA;
             for (int i = startWeightI; i < endWeightI; i++) {
-                double w = weights[i];
+                double w = weights[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
                 v += w * rasterA[idxA_ + 0];
                 
                 idxA_++;
@@ -87,7 +87,7 @@ void blur(double* rasterA, double* rasterB, int width, int height,
             
             int idxA_ = idxA;
             for (int i = startWeightI; i < endWeightI; i++) {
-                double w = weights[i];
+                double w = weights[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
                 v += w * rasterA[idxA_];
                 
                 idxA_ += rowInc;

--- a/src/Collision.c
+++ b/src/Collision.c
@@ -19,11 +19,9 @@ Vector collideCirclePolygons(Vector center, double radius,
             newCenter, radius, polygons, polygonsSize
         );
         
-        if (check2.pushVecsSize == 0) {
-            return newCenter;
-        } else if (check2.pushVecsSize == 1 && 
-            sameID(check1.ids[0], check2.ids[0])) {
-                
+        if (check2.pushVecsSize == 0 ||
+            (check2.pushVecsSize == 1 &&
+            sameID(check1.ids[0], check2.ids[0]))) {
             return newCenter;
         }
         
@@ -70,11 +68,9 @@ Vector collideCirclePolygons(Vector center, double radius,
             newCenter, radius, polygons, polygonsSize
         );
         
-        if (check2.pushVecsSize == 0) {
-            return newCenter;
-        } else if (check2.pushVecsSize == 1 && 
-            sameID(check1.ids[0], check2.ids[0])) {
-                
+        if (check2.pushVecsSize == 0 ||
+            (check2.pushVecsSize == 1 &&
+            sameID(check1.ids[0], check2.ids[0]))) {
             return newCenter;
         }
         
@@ -85,11 +81,9 @@ Vector collideCirclePolygons(Vector center, double radius,
             newCenter, radius, polygons, polygonsSize
         );
         
-        if (check2.pushVecsSize == 0) {
-            return newCenter;
-        } else if (check2.pushVecsSize == 1 && 
-            sameID(check1.ids[1], check2.ids[0])) {
-                
+        if (check2.pushVecsSize == 0 ||
+            (check2.pushVecsSize == 1 &&
+            sameID(check1.ids[1], check2.ids[0]))) {
             return newCenter;
         }
         
@@ -107,7 +101,7 @@ Vector collideCirclePolygons(Vector center, double radius,
 }
 
 CirclePolygonsCollision collideCirclePolygonsHelper(
-    Vector center, double radius, 
+    Vector center, double radius,
     const Polygon* const* polygons, int polygonsSize) {
         
     double r2 = radius * radius;

--- a/src/Line.c
+++ b/src/Line.c
@@ -66,7 +66,7 @@ void renderLine(Raster* screen, Vector p1, Vector p2, Color col,
         p2.y = y;
     }
     
-    if (abs(dx) >= abs(dy)) {
+    if (fabs(dx) >= fabs(dy)) {
         if (p2.x < p1.x) {
             Vector tmp = p1;
             p1 = p2;
@@ -76,7 +76,7 @@ void renderLine(Raster* screen, Vector p1, Vector p2, Color col,
         int startX = (int) (p1.x + 0.5);
         int endX = (int) (p2.x + 0.5);
         double startYExact = p1.y + dydx * (startX + 0.5 - p1.x);
-        double startY = (int) startYExact;
+        int startY = (int) startYExact;
         int yInc;
         double error;
         double errorInc;
@@ -114,7 +114,7 @@ void renderLine(Raster* screen, Vector p1, Vector p2, Color col,
         int startY = (int) (p1.y + 0.5);
         int endY = (int) (p2.y + 0.5);
         double startXExact = p1.x + dxdy * (startY + 0.5 - p1.y);
-        double startX = (int) startXExact;
+        int startX = (int) startXExact;
         int xInc;
         double error;
         double errorInc;
@@ -208,7 +208,7 @@ void renderLineDoubleBuffer(double* screen, int width, int height,
         p2.y = y;
     }
     
-    if (abs(dx) >= abs(dy)) {
+    if (fabs(dx) >= fabs(dy)) {
         if (p2.x < p1.x) {
             Vector tmp = p1;
             p1 = p2;
@@ -218,7 +218,7 @@ void renderLineDoubleBuffer(double* screen, int width, int height,
         int startX = (int) (p1.x + 0.5);
         int endX = (int) (p2.x + 0.5);
         double startYExact = p1.y + dydx * (startX + 0.5 - p1.x);
-        double startY = (int) startYExact;
+        int startY = (int) startYExact;
         int yInc;
         double error;
         double errorInc;
@@ -254,7 +254,7 @@ void renderLineDoubleBuffer(double* screen, int width, int height,
         int startY = (int) (p1.y + 0.5);
         int endY = (int) (p2.y + 0.5);
         double startXExact = p1.x + dxdy * (startY + 0.5 - p1.y);
-        double startX = (int) startXExact;
+        int startX = (int) startXExact;
         int xInc;
         double error;
         double errorInc;

--- a/src/Parallax.c
+++ b/src/Parallax.c
@@ -52,6 +52,7 @@ void renderParallax(Raster* screen, const Polygon* const* polygons,
     }
     if (doCap) {
         for (int j = 0; j < polygonsSize; j++) { 
+            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
             RenderPolygon_Render(renderPolygons[j], screen,
                 capCol, combined.offset, combined.scale);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include "App.h"
 #include "Vector.h"


### PR DESCRIPTION
this changes how `SDL.h` is imported, but makes it so you shouldn't need to configure a special import path if you have libsdl2-dev installed in a standard location

you may want to disable the `NOLINT`s I added to inspect the errors I'm suppressing later